### PR TITLE
Ensure that default file/protocol handlers are re-installed after upd…

### DIFF
--- a/src/renderer/lib/migrations.js
+++ b/src/renderer/lib/migrations.js
@@ -29,8 +29,21 @@ function run (state) {
   if (semver.lt(version, '0.17.0')) migrate_0_17_0(saved)
   if (semver.lt(version, '0.17.2')) migrate_0_17_2(saved)
 
+  if (semver.lt(version, config.APP_VERSION)) {
+    installHandlers(state.saved)
+  }
+
   // Config is now on the new version
   state.saved.version = config.APP_VERSION
+}
+
+// Whenever the app is updated,  re-install default handlers if the user has
+// enabled them.
+function installHandlers (saved) {
+  if (saved.prefs.isFileHandler) {
+    const ipcRenderer = require('electron').ipcRenderer
+    ipcRenderer.send('setDefaultFileHandler', true)
+  }
 }
 
 function migrate_0_7_0 (saved) {


### PR DESCRIPTION
…ating.

Previously, they were only installed when the preference was changed.
This caused the handlers to point to non-existing files after updates
occurred and older versions were removed by Squirrel.

Closes #791, #911.